### PR TITLE
Add emulator test TODO and preserve nightscout CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,36 @@
 # CircleCI configuration for bcoster22/AndroidAPS fork
 # Uses CircleCI cloud runners (not nightscout's self-hosted runners)
+#
+# TODO (future version): Add Android emulator + connectedFullDebugAndroidTest
+# ─────────────────────────────────────────────────────────────────────────────
+# Nightscout's original config uses a self-hosted runner (resource_class: nightscout/android)
+# with a pre-configured Android emulator for instrumentation tests:
+#
+#   machine: true
+#   resource_class: nightscout/android
+#
+#   Emulator setup:
+#     - System image: system-images;android-31;google_apis_playstore;x86_64
+#     - AVD created via: avdmanager create avd -n citest -k <system-image>
+#     - Emulator launched with: emulator -avd citest -delay-adb -verbose
+#         -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+#     - ANDROID_SDK_ROOT=/usr/lib/android-sdk
+#     - ANDROID_HOME=/usr/lib/android-sdk
+#
+#   Test commands (after emulator boot):
+#     - ./gradlew connectedFullDebugAndroidTest
+#     - adb devices | grep emulator | cut -f1 | while read -r line; do adb -s $line emu kill; done
+#
+# To replicate this on a self-hosted runner:
+#   1. Set up a Linux machine with Android SDK, cmdline-tools, and emulator installed
+#   2. Install the CircleCI self-hosted runner agent
+#   3. Register it as resource_class: bcoster22/android
+#   4. Pre-install system image: sdkmanager "system-images;android-31;google_apis_playstore;x86_64"
+#   5. Switch this config to use: machine: true / resource_class: bcoster22/android
+#   6. Add emulator create/launch/kill steps from nightscout's original config
+#
+# See nightscout's original config preserved in: .circleci/config.yml.nightscout
+# ─────────────────────────────────────────────────────────────────────────────
 version: 2.1
 
 orbs:

--- a/.circleci/config.yml.nightscout
+++ b/.circleci/config.yml.nightscout
@@ -1,0 +1,113 @@
+ # Use the latest 2.1 version of CircleCI pipeline process engine. 
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+orbs:
+  android: circleci/android@2.4.0
+  codecov: codecov/codecov@3.3.0
+
+jobs:
+  # Below is the definition of your job to build and test your app, you can rename and customize it as you want.
+  build-and-test:
+    machine: true
+    resource_class: nightscout/android
+
+    steps:
+      - checkout
+
+      - run:
+          name: Run compileFullDebugAndroidTestSources
+          command: |
+            export ANDROID_SDK_ROOT=/usr/lib/android-sdk
+            export ANDROID_HOME=/usr/lib/android-sdk
+            env
+            ./gradlew \
+            -Dorg.gradle.jvmargs="-Xmx8g -XX:+UseParallelGC -Xss1024m" \
+            -Dkotlin.daemon.jvm.options="-Xmx2g" \
+            -Dkotlin.compiler.execution.strategy="in-process" \
+            -Dorg.gradle.daemon=true \
+            compileFullDebugAndroidTestSources
+
+      - run:
+          name: Create avd
+          command: |
+            echo "no" | /usr/lib/android-sdk/cmdline-tools/13.0/bin/avdmanager --verbose create avd -n citest -k "system-images;android-31;google_apis_playstore;x86_64" --force
+
+      - run:
+          name: Launch emulator
+          command: |
+            export ANDROID_SDK_ROOT=/usr/lib/android-sdk
+            export ANDROID_HOME=/usr/lib/android-sdk
+            emulator -avd citest -delay-adb -verbose -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
+          background: true
+
+      - run:
+          name: Run connectedFullDebugAndroidTest
+          command: |
+            export ANDROID_SDK_ROOT=/usr/lib/android-sdk
+            export ANDROID_HOME=/usr/lib/android-sdk
+            env
+            ./gradlew \
+            -Dorg.gradle.jvmargs="-Xmx8g -XX:+UseParallelGC -Xss1024m" \
+            -Dkotlin.daemon.jvm.options="-Xmx2g" \
+            -Dkotlin.compiler.execution.strategy="in-process" \
+            -Dorg.gradle.daemon=true \
+            connectedFullDebugAndroidTest
+          
+      - run:
+          name: Kill emulators
+          command: |
+            echo "Killing emulators"
+            adb devices | grep emulator | cut -f1 | while read -r line; do adb -s $line emu kill; done
+          
+      - run:
+          name: Run testFullDebugUnitTest
+          command: |
+            export ANDROID_SDK_ROOT=/usr/lib/android-sdk
+            export ANDROID_HOME=/usr/lib/android-sdk
+            ./gradlew \
+            -Dorg.gradle.jvmargs="-Xmx8g -XX:+UseParallelGC -Xss1024m" \
+            -Dkotlin.daemon.jvm.options="-Xmx2g" \
+            -Dkotlin.compiler.execution.strategy="in-process" \
+            -Dorg.gradle.workers.max=22 \
+            -Dorg.gradle.daemon=true \
+            testFullDebugUnitTest
+
+      - run:
+          run: Run jacocoAllDebugReport
+          command: |
+            export ANDROID_SDK_ROOT=/usr/lib/android-sdk
+            export ANDROID_HOME=/usr/lib/android-sdk
+            ./gradlew --stacktrace jacocoAllDebugReport
+
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/build/outputs/androidTest-results/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+
+      - store_test_results:
+          path: ~/test-results
+
+      - store_artifacts:
+          path: ~/test-results/junit
+
+      - codecov/upload:
+          file: './build/reports/jacoco/jacocoAllDebugReport/jacocoAllDebugReport.xml'
+
+      - run:
+          name: Kill java processes
+          command: |
+            killall java
+          when: always
+
+workflows:
+  # Below is the definition of your workflow.
+  # Inside the workflow, you provide the jobs you want to run, e.g this workflow runs the build-and-test job above.
+  # CircleCI will run this workflow on every commit.
+  # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows
+  dotests:
+    jobs:
+      - build-and-test


### PR DESCRIPTION
- Detailed TODO in config.yml with nightscout's self-hosted runner setup for future emulator test support
- Preserved nightscout's original config as .circleci/config.yml.nightscout for reference